### PR TITLE
ci: validate compose + Caddyfile + shell scripts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,23 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Validate every per-stack docker-compose.yml
+      - name: Validate every per-stack compose file
         run: |
           set -e
           failed=0
           shopt -s nullglob
-          for compose in */docker-compose.yml; do
-            dir=$(dirname "$compose")
+          # docker compose auto-discovers any of these four names — match the
+          # same set so renaming a stack from .yml to .yaml doesn't silently
+          # drop it from CI. Iterate unique directories.
+          mapfile -t dirs < <(
+            printf '%s\n' \
+              */docker-compose.yml \
+              */docker-compose.yaml \
+              */compose.yml \
+              */compose.yaml \
+            | xargs -I{} dirname {} | sort -u
+          )
+          for dir in "${dirs[@]}"; do
             echo "::group::$dir"
             pushd "$dir" >/dev/null
             # Compose needs a .env to resolve ${VAR} references; the sample
@@ -30,7 +40,7 @@ jobs:
               fi
             fi
             if ! docker compose config --quiet; then
-              echo "::error file=$compose::docker compose config failed"
+              echo "::error file=$dir::docker compose config failed"
               failed=1
             fi
             popd >/dev/null

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,62 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  compose-validate:
+    name: docker compose config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate every per-stack docker-compose.yml
+        run: |
+          set -e
+          failed=0
+          shopt -s nullglob
+          for compose in */docker-compose.yml; do
+            dir=$(dirname "$compose")
+            echo "::group::$dir"
+            pushd "$dir" >/dev/null
+            # Compose needs a .env to resolve ${VAR} references; the sample
+            # files in this repo are the source of truth for what vars exist.
+            if [ ! -f .env ]; then
+              if [ -f .env.sample ]; then
+                cp .env.sample .env
+              elif [ -f .env.example ]; then
+                cp .env.example .env
+              fi
+            fi
+            if ! docker compose config --quiet; then
+              echo "::error file=$compose::docker compose config failed"
+              failed=1
+            fi
+            popd >/dev/null
+            echo "::endgroup::"
+          done
+          exit $failed
+
+  caddyfile-validate:
+    name: caddy validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Caddyfile
+        run: |
+          docker run --rm \
+            -v "$PWD/caddy/Caddyfile:/etc/caddy/Caddyfile:ro" \
+            -e DOMAIN=example.com \
+            -e EMAIL=ci@example.com \
+            caddy:2 \
+            caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ludeeus/action-shellcheck@master
+        env:
+          SHELLCHECK_OPTS: --severity=warning


### PR DESCRIPTION
## Summary
Adds `.github/workflows/ci.yml` with three jobs that run on every PR (and on pushes to main):

- **compose-validate** — `docker compose config --quiet` on every per-stack `docker-compose.yml`, with the stack's `.env.sample` (or `.env.example`) copied to `.env` so `\${VAR}` references resolve. Catches malformed YAML, missing required env vars, broken service/network refs — exactly the kind of breakage the recent 20-file network refactor risked.
- **caddyfile-validate** — `caddy validate` via the official `caddy:2` image with placeholder DOMAIN/EMAIL.
- **shellcheck** — `ludeeus/action-shellcheck` at `severity: warning`. Existing scripts pass cleanly; we don't flag info-level SC2086 (unquoted paths) since most are well-known directory variables without spaces.

Dry-run locally: all three pass on the current `main`.

## Why
Catch refactor bugs and bash bugs before they ship rather than at deploy time. Especially valuable on a 20-stack repo where a sed-based rename or env-var typo is easy to make and silently breaks one stack.

## Test plan
- [ ] PR triggers the workflow; all three jobs pass on this branch
- [ ] Intentionally break a compose file (e.g., remove a network reference) in a follow-up PR — compose-validate fails
- [ ] Add `echo \$undefined_var` in some init.sh — shellcheck job still passes (info severity), but adding `set -u` and using `$nope` would fail (warning severity)
- [ ] Future PRs (incl. the stacked opencloud / caddy-network-isolation ones) pick up the workflow after their next rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)